### PR TITLE
fix: setupUi calls moveEvent before QSettings causing race condition and crash at launch in DocumentWindow

### DIFF
--- a/cadnano2/views/documentwindow.py
+++ b/cadnano2/views/documentwindow.py
@@ -39,8 +39,8 @@ class DocumentWindow(QMainWindow, ui_mainwindow.Ui_MainWindow):
         super(DocumentWindow, self).__init__(parent)
         self.controller = docCtrlr
         doc = docCtrlr.document()
-        self.setupUi(self)
         self.settings = QSettings()
+        self.setupUi(self)
         self._readSettings()
         # Slice setup
         self.slicescene = QGraphicsScene(parent=self.sliceGraphicsView)


### PR DESCRIPTION
Bug: moveEvent is called by setupUi but references settings attribute before it is set by QSettings, creating AttributeError and crash at startup

Fix: Moved QSettings initialization before setupUi